### PR TITLE
Add two packages to help support Scikit-Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
     # Tifffile
     - pip wheel -w $WHEELHOUSE -v tifffile
 script:
-    - pip install -f $WHEELHOUSE cython numpy==$NUMPY_VERSION scipy matplotlib pillow networkx
+    - pip install -f $WHEELHOUSE cython numpy==$NUMPY_VERSION scipy matplotlib pillow networkx tifffile
 before_deploy: cd $WHEELHOUSE
 deploy:
   provider: cloudfiles


### PR DESCRIPTION
Scikit-image is adding [tifffile](https://pypi.python.org/pypi/tifffile) as a dependency, and also tests against Cython==0.19.2 in one of its builds.
