### PR TITLE
Avoid installing from PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
     # Tifffile
     - pip wheel -w $WHEELHOUSE -v tifffile
 script:
-    - pip install -f $WHEELHOUSE cython numpy==$NUMPY_VERSION scipy matplotlib pillow networkx tifffile
+    - pip install --no-index -f $WHEELHOUSE cython numpy==$NUMPY_VERSION scipy matplotlib pillow networkx tifffile
 before_deploy: cd $WHEELHOUSE
 deploy:
   provider: cloudfiles


### PR DESCRIPTION
For some reason it was still trying to install Matplotlib 1.4.0 on Py3.2 even though 1.3.1 was installed.  Thanks, pip....
